### PR TITLE
fix: move worker video download to reporter

### DIFF
--- a/.changeset/brown-ligers-deliver.md
+++ b/.changeset/brown-ligers-deliver.md
@@ -1,0 +1,5 @@
+---
+"appwright": patch
+---
+
+fix: move worker video download to reporter

--- a/src/fixture/index.ts
+++ b/src/fixture/index.ts
@@ -81,7 +81,9 @@ export const test = base.extend<TestLevelFixtures, WorkerLevelFixtures>({
         ?.provider;
       const providerClass = getProviderClass(providerName!);
       const fileName = `worker-${workerIndex}-video`;
-      await providerClass.downloadVideo(sessionId, basePath(), fileName);
+      if (providerClass.downloadVideo) {
+        await providerClass.downloadVideo(sessionId, basePath(), fileName);
+      }
     },
     { scope: "worker" },
   ],

--- a/src/fixture/index.ts
+++ b/src/fixture/index.ts
@@ -8,7 +8,6 @@ import {
 } from "../types";
 import { Device } from "../device";
 import { createDeviceProvider } from "../providers";
-import { logger } from "../logger";
 import { WorkerInfoStore } from "./workerInfo";
 
 type TestLevelFixtures = {
@@ -77,9 +76,8 @@ export const test = base.extend<TestLevelFixtures, WorkerLevelFixtures>({
         afterSession,
       );
       await use(device);
-      await device.close();
-      logger.log(`Teardown for worker ${workerIndex}, will download video`);
       await workerInfoStore.saveWorkerEndTime(workerIndex, new Date());
+      await device.close();
     },
     { scope: "worker" },
   ],

--- a/src/fixture/workerInfo.ts
+++ b/src/fixture/workerInfo.ts
@@ -7,7 +7,7 @@ type TestInWorkerInfo = {
   startTime: string;
 };
 
-type WorkerInfo = {
+export type WorkerInfo = {
   idx: number;
   sessionId?: string | undefined;
   providerName?: string | undefined;
@@ -57,13 +57,6 @@ export class WorkerInfoStore {
     return new Date(info.startTime.afterAppiumSession);
   }
 
-  async getWorkerEndTime(idx: number): Promise<Date | undefined> {
-    const info = await this.getWorkerFromDisk(idx);
-    if (info && info.endTime) {
-      return new Date(info.endTime);
-    }
-  }
-
   async saveWorkerStartTime(
     idx: number,
     sessionId: string,
@@ -72,21 +65,24 @@ export class WorkerInfoStore {
     afterAppiumSession: Date,
   ) {
     let info = await this.getWorkerFromDisk(idx);
+    const delta = {
+      providerName,
+      sessionId,
+      startTime: {
+        beforeAppiumSession: beforeAppiumSession.toISOString(),
+        afterAppiumSession: afterAppiumSession.toISOString(),
+      },
+    };
     if (!info) {
       info = {
+        ...delta,
         idx,
-        providerName,
-        sessionId,
-        startTime: {
-          beforeAppiumSession: beforeAppiumSession.toISOString(),
-          afterAppiumSession: afterAppiumSession.toISOString(),
-        },
         tests: [],
       };
     } else {
-      info.startTime = {
-        beforeAppiumSession: beforeAppiumSession.toISOString(),
-        afterAppiumSession: afterAppiumSession.toISOString(),
+      info = {
+        ...info,
+        ...delta,
       };
     }
     return this.saveWorkerToDisk(idx, info);

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -113,7 +113,12 @@ class VideoDownloader implements Reporter {
     }
   }
 
-  attachVideoToDeviceTest(
+  async onEnd() {
+    logger.log(`Triggered onEnd`);
+    await Promise.allSettled(this.downloadPromises);
+  }
+
+  private attachVideoToDeviceTest(
     test: TestCase,
     result: TestResult,
     providerClass: any,
@@ -142,11 +147,6 @@ class VideoDownloader implements Reporter {
         );
     });
     this.downloadPromises.push(downloadPromise);
-  }
-
-  async onEnd() {
-    logger.log(`Triggered onEnd`);
-    await Promise.allSettled(this.downloadPromises);
   }
 }
 
@@ -196,6 +196,11 @@ function trimVideo({
 async function workerStartTime(idx: number): Promise<Date> {
   const workerInfoStore = new WorkerInfoStore();
   return workerInfoStore.getWorkerStartTime(idx);
+}
+
+async function workerEndTime(idx: number): Promise<Date | undefined> {
+  const workerInfoStore = new WorkerInfoStore();
+  return workerInfoStore.getWorkerEndTime(idx);
 }
 
 export default VideoDownloader;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,19 +31,6 @@ export interface DeviceProvider {
   getDevice(): Promise<Device>;
 
   /**
-   * Downloads the video of the test.
-   * Currently, this functionality is supported only for BrowserStack.
-   *
-   * @param outputDir directory to save the video
-   * @param fileName name of the downloaded video file
-   * @returns
-   */
-  downloadVideo?: (
-    outputDir: string,
-    fileName: string,
-  ) => Promise<{ path: string; contentType: string } | null>;
-
-  /**
    * Updates test details and test status.
    *
    * @param status of the test


### PR DESCRIPTION
This change moves `persistentDevice` video downloading to the reporter. Since the reporter does not know when workers end, the tricky bit was to figure out how to know when to download the video. To do that, I've extended `WorkerInfoStore` to maintain worker `endTime`, which is checked by the reporter in `onTestEnd`. The rest of the trimming logic is the same.

This also closes #60 by exiting early if the provider cannot download videos.