### PR TITLE
fix: Uiautomator version matches appium version

### DIFF
--- a/.changeset/plenty-rocks-wash.md
+++ b/.changeset/plenty-rocks-wash.md
@@ -1,0 +1,5 @@
+---
+"appwright": patch
+---
+
+Matching uiautomator2 version to appium version

--- a/src/providers/emulator/index.ts
+++ b/src/providers/emulator/index.ts
@@ -66,8 +66,8 @@ Follow the steps mentioned in ${androidSimulatorConfigDocLink} to run test on An
   }
 
   private async createDriver(): Promise<Device> {
-    const appiumMajorVersion = dependencies.appium.split('.')[0];
-    const uiAutomatorVersion = appiumMajorVersion.includes('2')
+    const appiumMajorVersion = dependencies.appium.split(".")[0] ?? "";
+    const uiAutomatorVersion = appiumMajorVersion.includes("2")
       ? "uiautomator2@2"
       : "uiautomator2";
     await installDriver(

--- a/src/providers/emulator/index.ts
+++ b/src/providers/emulator/index.ts
@@ -15,6 +15,7 @@ import {
 import { FullProject } from "@playwright/test";
 import { validateBuildPath } from "../../utils";
 import { logger } from "../../logger";
+import { dependencies } from "../../../package.json";
 
 export class EmulatorProvider implements DeviceProvider {
   sessionId?: string;
@@ -65,9 +66,13 @@ Follow the steps mentioned in ${androidSimulatorConfigDocLink} to run test on An
   }
 
   private async createDriver(): Promise<Device> {
+    const appiumMajorVersion = dependencies.appium.split('.')[0];
+    const uiAutomatorVersion = appiumMajorVersion.includes('2')
+      ? "uiautomator2@2"
+      : "uiautomator2";
     await installDriver(
       this.project.use.platform == Platform.ANDROID
-        ? "uiautomator2"
+        ? uiAutomatorVersion
         : "xcuitest",
     );
     await startAppiumServer(this.project.use.device?.provider!);


### PR DESCRIPTION
after appium released 3.x.x, latest uiautomator2 without a version number expects minimum appium version to be 3.x.x. This code sets uiautomator2@2 when package json has 2 as the major version for appium