### PR TITLE
chore: bump Playwright to 1.56.1

### DIFF
--- a/.changeset/playwright-1-56-1.md
+++ b/.changeset/playwright-1-56-1.md
@@ -1,0 +1,5 @@
+---
+"appwright": patch
+---
+
+- chore: upgrade `@playwright/test` dependency to 1.56.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "appwright",
-  "version": "0.1.37",
+  "version": "0.1.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appwright",
-      "version": "0.1.37",
+      "version": "0.1.46",
       "license": "Apache-2.0",
       "dependencies": {
         "@empiricalrun/llm": "^0.9.25",
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
-        "@playwright/test": "^1.47.1",
+        "@playwright/test": "^1.56.1",
         "appium": "^2.6.0",
         "appium-uiautomator2-driver": "^3.8.0",
         "appium-xcuitest-driver": "^7.27.0",
@@ -2906,12 +2906,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.47.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.2.tgz",
-      "integrity": "sha512-jTXRsoSPONAs8Za9QEQdyjFn+0ZQFjCiIztAIF6bi1HqhBzG9Ma7g1WotyiGqFSBRZjIEqMdT8RUlbk1QVhzCQ==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.47.2"
+        "playwright": "1.56.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -21276,12 +21276,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.47.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.2.tgz",
-      "integrity": "sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.47.2"
+        "playwright-core": "1.56.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -21294,9 +21294,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.47.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.2.tgz",
-      "integrity": "sha512-3JvMfF+9LJfe16l7AbSmU555PaTl2tPyQsVInqm3id16pdDfvZ8TTZ/pyzmkbDrZTQefyzU7AIHlZqQnxpqHVQ==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@empiricalrun/llm": "^0.9.25",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "@playwright/test": "^1.47.1",
+    "@playwright/test": "^1.56.1",
     "appium": "^2.6.0",
     "appium-uiautomator2-driver": "^3.8.0",
     "appium-xcuitest-driver": "^7.27.0",


### PR DESCRIPTION
## Summary
- upgrade @playwright/test to 1.56.1 so Appwright consumes the latest runner
- add a changeset entry documenting the dependency update

## Testing
- npm run build